### PR TITLE
Remove ‘prepare_binds_for_database’ internal method

### DIFF
--- a/lib/activerecord/insert_many.rb
+++ b/lib/activerecord/insert_many.rb
@@ -39,7 +39,7 @@ module ActiveRecord
           end
         end
 
-        prepare_binds_for_database(binds).map do |value|
+        binds.map(&:value_for_database).map do |value|
           begin
             quote(value)
           rescue TypeError


### PR DESCRIPTION
The internal method `prepare_binds_for_database` was [removed in `5.1.0.rc1`](https://github.com/rails/rails/pull/25937).

