### PR TITLE
Cast values returned from insert

### DIFF
--- a/activerecord-insert_many.gemspec
+++ b/activerecord-insert_many.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activerecord", ">= 5.0"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "minitest-reporters-turn_reporter"


### PR DESCRIPTION
Values returned in a `PG::Result` (or an `ActiveRecord::Result`, for that matter) aren't cast using ActiveRecord's type casting. This means that, for example, a custom type-casting for uuids that removed dashes from the string and would be applied for other fetches out of the database (including `.pluck`) wouldn't be applied to an `insert_many` that returned `id`. Therefore, we have to implement that casting ourselves, grabbing the appropriate type and applying it to any returned values so that those values are consistent with their counterparts pulled out of the database in a different way.